### PR TITLE
Point to build directory in peek.yml

### DIFF
--- a/peek.yml
+++ b/peek.yml
@@ -1,5 +1,5 @@
 version: 2
 main:
   type: static
-  path: ./public
-  spa: false
+  path: ./build
+  spa: true


### PR DESCRIPTION
The built assets get generated in `/build`, so we want to let FeaturePeek know that. 

Also, create-react-app generates an SPA (HTTP request misses go through index.html instead of returning a 404), so we set `spa` to `true`. 